### PR TITLE
Update paper-color-picker to Polymer 1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bower_components

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,22 @@
+{
+  "name": "paper-color-picker",
+  "homepage": "https://github.com/David-Mulder/paper-color-picker",
+  "authors": [
+    "David Mulder",
+    "Dennis Kugelmann"
+  ],
+  "description": "A paper color picker inspired by Material Design",
+  "main": "paper-color-picker.html",
+  "keywords": [
+    "web-components",
+    "polymer",
+    "color-picker",
+    "material-design"
+  ],
+  "license": "https://github.com/David-Mulder/paper-color-picker/blob/master/LICENSE",
+  "dependencies": {
+    "paper-dialog": "PolymerElements/paper-dialog#~1.0.3",
+    "iron-component-page": "PolymerElements/iron-component-page#~1.1.2",
+    "paper-slider": "PolymerElements/paper-slider#~1.0.8"
+  }
+}

--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "paper-dialog": "PolymerElements/paper-dialog#~1.0.3",
     "iron-component-page": "PolymerElements/iron-component-page#~1.1.2",
-    "paper-slider": "PolymerElements/paper-slider#~1.0.8"
+    "paper-slider": "PolymerElements/paper-slider#~1.0.8",
+    "neon-animation": "PolymerElements/neon-animation#~1.0.8"
   }
 }

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -15,10 +15,10 @@
 
   <title>paper-input</title>
 
-  <script src="bower_components/webcomponentsjs/webcomponents.js"></script>
+  <script src="../bower_components/webcomponentsjs/webcomponents.js"></script>
 
-  <link href="bower_components/paper-dialog/paper-dialog.html" rel="import">
-  <link href="bower_components/paper-button/paper-button.html" rel="import">
+  <link href="../bower_components/paper-dialog/paper-dialog.html" rel="import">
+  <link href="../bower_components/paper-button/paper-button.html" rel="import">
 
   <link href="../paper-color-circle.html" rel="import">
   <link href="../paper-color-picker.html" rel="import">

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -15,12 +15,10 @@
 
   <title>paper-input</title>
 
-  <script src="../webcomponentsjs/webcomponents.js"></script>
+  <script src="bower_components/webcomponentsjs/webcomponents.js"></script>
 
-  <link href="../font-roboto/roboto.html" rel="import">
-
-  <link href="../paper-dialog/paper-dialog.html" rel="import">
-  <link href="../paper-button/paper-button.html" rel="import">
+  <link href="bower_components/paper-dialog/paper-dialog.html" rel="import">
+  <link href="bower_components/paper-button/paper-button.html" rel="import">
 
   <link href="paper-color-circle.html" rel="import">
   <link href="paper-color-picker.html" rel="import">

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -15,10 +15,10 @@
 
   <title>paper-input</title>
 
-  <script src="../bower_components/webcomponentsjs/webcomponents.js"></script>
+  <script src="../../webcomponentsjs/webcomponents.js"></script>
 
-  <link href="../bower_components/paper-dialog/paper-dialog.html" rel="import">
-  <link href="../bower_components/paper-button/paper-button.html" rel="import">
+  <link href="../../paper-dialog/paper-dialog.html" rel="import">
+  <link href="../../paper-button/paper-button.html" rel="import">
 
   <link href="../paper-color-circle.html" rel="import">
   <link href="../paper-color-picker.html" rel="import">

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -20,8 +20,8 @@
   <link href="bower_components/paper-dialog/paper-dialog.html" rel="import">
   <link href="bower_components/paper-button/paper-button.html" rel="import">
 
-  <link href="paper-color-circle.html" rel="import">
-  <link href="paper-color-picker.html" rel="import">
+  <link href="../paper-color-circle.html" rel="import">
+  <link href="../paper-color-picker.html" rel="import">
 
   <style shim-shadowdom>
 
@@ -52,7 +52,8 @@
 <body unresolved>
 
   <section>
-    <div>Standalone</div>
+    <a href="../index.html">Back</a>
+    <h1>Standalone</h1>
 
     <br>
 
@@ -66,7 +67,7 @@
   </section>
   
   <section>
-    <div>Dialog</div>
+    <h1>Dialog</h1>
 
     <br>
 

--- a/index.html
+++ b/index.html
@@ -13,10 +13,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <link rel="import" href="bower_components/polymer/polymer.html">
   <link rel="import" href="bower_components/iron-component-page/iron-component-page.html">
+  <link rel="import" href="paper-color-picker.html">
 
 </head>
 <body>
 
-  <iron-component-page></iron-component-page>
+  <paper-color-picker></paper-color-picker>
 
-</body></html>
+  <script type="text/javascript">
+  	document.querySelector('paper-color-picker').open();
+  </script>
+
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -9,10 +9,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <html>
 <head>
 
-  <script src="bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../webcomponentsjs/webcomponents-lite.js"></script>
 
-  <link rel="import" href="bower_components/polymer/polymer.html">
-  <link rel="import" href="bower_components/iron-component-page/iron-component-page.html">
+  <link rel="import" href="../polymer/polymer.html">
+  <link rel="import" href="../iron-component-page/iron-component-page.html">
 
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -9,10 +9,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <html>
 <head>
 
-  <script src="../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="bower_components/webcomponentsjs/webcomponents-lite.js"></script>
 
-  <link rel="import" href="../polymer/polymer.html">
-  <link rel="import" href="../iron-component-page/iron-component-page.html">
+  <link rel="import" href="bower_components/polymer/polymer.html">
+  <link rel="import" href="bower_components/iron-component-page/iron-component-page.html">
 
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,4 @@
-<!doctype html>
-<!--
+<!DOCTYPE html><!--
 Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
 This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE
 The complete set of authors may be found at http://polymer.github.io/AUTHORS
@@ -10,13 +9,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <html>
 <head>
 
-  <script src="../webcomponentsjs/webcomponents.js"></script>
-  <link rel="import" href="../core-component-page/core-component-page.html">
+  <script src="../webcomponentsjs/webcomponents-lite.js"></script>
+
+  <link rel="import" href="../polymer/polymer.html">
+  <link rel="import" href="../iron-component-page/iron-component-page.html">
 
 </head>
-<body unresolved>
+<body>
 
-  <core-component-page sources='["paper-color-picker.html"]'></core-component-page>
+  <iron-component-page></iron-component-page>
 
-</body>
-</html>
+</body></html>

--- a/index.html
+++ b/index.html
@@ -13,16 +13,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <link rel="import" href="bower_components/polymer/polymer.html">
   <link rel="import" href="bower_components/iron-component-page/iron-component-page.html">
-  <link rel="import" href="paper-color-picker.html">
 
 </head>
 <body>
 
-  <paper-color-picker></paper-color-picker>
-
-  <script type="text/javascript">
-  	document.querySelector('paper-color-picker').open();
-  </script>
+  <iron-component-page></iron-component-page>
 
 </body>
 </html>

--- a/paper-color-circle.html
+++ b/paper-color-circle.html
@@ -166,10 +166,7 @@
            * @default new Array(2)
            */
           color: {
-            type: Array,
-            value: function () {
-              return [];
-            },
+            type: Object,
             notify: true,
             observer: 'colorChanged'
           },
@@ -265,11 +262,11 @@
           var touchY = e.detail.y - rect.top;
           var color = this._ctx.getImageData(touchX, touchY, 1, 1).data;
           if (color[3] > 0) {
-            this.color = [
-              color[0],
-              color[1],
-              color[2]
-            ];
+            this.color = {
+              red: color[0],
+              green: color[1],
+              blue: color[2]
+            };
             if (redraw)
               this.redraw();
           }
@@ -301,7 +298,7 @@
             }
             this._moveStart = false;
           }
-          this.set('$.ripple.style.color', 'rgb(' + this.color[0] + ',' + this.color[1] + ',' + this.color[2] + ')');
+          this.set('$.ripple.style.color', 'rgb(' + this.color['red'] + ',' + this.color['green'] + ',' + this.color['blue'] + ')');
         },
         redraw: function () {
           var size = this.getBoundingClientRect();
@@ -394,8 +391,8 @@
         },
         drawAACircle: function () {
           if (this.colouredAAborder) {
-            if (this.color[1]) {
-              this.set('_ctx.strokeStyle', 'rgb(' + this.color[0] + ',' + this.color[1] + ',' + this.color[2] + ')');
+            if (this.color['green']) {
+              this.set('_ctx.strokeStyle', 'rgb(' + this.color['red'] + ',' + this.color['green'] + ',' + this.color['blue'] + ')');
             } else {
               this.set('_ctx.strokeStyle', 'rgb(' + this.colouredAAborder[0] + ',' + this.colouredAAborder[1] + ',' + this.colouredAAborder[2] + ')');
             }

--- a/paper-color-circle.html
+++ b/paper-color-circle.html
@@ -12,6 +12,7 @@
       height: 100%;
       min-width: 100px;
       min-height: 100px;
+      cursor: crosshair;
     }
     #ripple{
       position: absolute;

--- a/paper-color-circle.html
+++ b/paper-color-circle.html
@@ -1,5 +1,5 @@
-<link href="bower_components/polymer/polymer.html" rel="import">
-<link href="bower_components/paper-ripple/paper-ripple.html" rel="import">
+<link href="../polymer/polymer.html" rel="import">
+<link href="../paper-ripple/paper-ripple.html" rel="import">
 
 <dom-module id="paper-color-circle">
   <style>

--- a/paper-color-circle.html
+++ b/paper-color-circle.html
@@ -432,7 +432,7 @@
           if (this._domReady)
             this.redraw();
         },
-        ready: function () {
+        attached: function () {
           this._domReady = true;
           this._ctx = this.$.canvas.getContext('2d');
           this.redraw();

--- a/paper-color-circle.html
+++ b/paper-color-circle.html
@@ -5,20 +5,20 @@
   <style>
     :host {
       display: inline-block;
-      position: relative;
+      position:relative;
     }
     canvas{
-      width: 100%;
-      height: 100%;
-      min-width: 100px;
-      min-height: 100px;
+      width:100%;
+      height:100%;
+      min-width:100px;
+      min-height:100px;
     }
     #ripple{
-      position: absolute;
-      left: 0px;
-      top: 0px;
-      bottom: 0px;
-      right: 0px;
+      position:absolute;
+      left:0px;
+      top:0px;
+      bottom:0px;
+      right:0px;
       pointer-events: none;
     }
   </style>

--- a/paper-color-circle.html
+++ b/paper-color-circle.html
@@ -5,20 +5,20 @@
   <style>
     :host {
       display: inline-block;
-      position:relative;
+      position: relative;
     }
     canvas{
-      width:100%;
-      height:100%;
-      min-width:100px;
-      min-height:100px;
+      width: 100%;
+      height: 100%;
+      min-width: 100px;
+      min-height: 100px;
     }
     #ripple{
-      position:absolute;
-      left:0px;
-      top:0px;
-      bottom:0px;
-      right:0px;
+      position: absolute;
+      left: 0px;
+      top: 0px;
+      bottom: 0px;
+      right: 0px;
       pointer-events: none;
     }
   </style>

--- a/paper-color-circle.html
+++ b/paper-color-circle.html
@@ -1,10 +1,7 @@
 <link href="../polymer/polymer.html" rel="import">
 <link href="../paper-ripple/paper-ripple.html" rel="import">
 
-<polymer-element name="paper-color-circle">
-
-<template>
-
+<dom-module id="paper-color-circle">
   <style>
     :host {
       display: inline-block;
@@ -25,301 +22,422 @@
       pointer-events: none;
     }
   </style>
-  <paper-ripple id="ripple" class="{{shape}}"></paper-ripple>
-  <canvas id="canvas" on-down="{{onDown}}" on-up="{{onUp}}" on-track="{{onMove}}"></canvas>
+  <template>
+  <paper-ripple id="ripple" class$="{{shape}}"></paper-ripple>
+  <canvas id="canvas" on-down="onDown" on-up="onUp" on-track="onMove"></canvas>
 </template>
-
-<script>
-
-  (function(){
-
-    function hsv2rgb(h, s, v) {
-      var c = v * s;
-      var h1 = h / 60;
-      var x = c * (1 - Math.abs((h1 % 2) - 1));
-      var m = v - c;
-      var rgb;
-
-      if (typeof h == 'undefined') rgb = [0, 0, 0];
-      else if (h1 < 1) rgb = [c, x, 0];
-      else if (h1 < 2) rgb = [x, c, 0];
-      else if (h1 < 3) rgb = [0, c, x];
-      else if (h1 < 4) rgb = [0, x, c];
-      else if (h1 < 5) rgb = [x, 0, c];
-      else if (h1 <= 6) rgb = [c, 0, x];
-
-      return [255 * (rgb[0] + m), 255 * (rgb[1] + m), 255 * (rgb[2] + m)];
-    }
-    
-    function hsl2rgb(h, s, l){
+  <script>
+    (function () {
+      function hsv2rgb(h, s, v) {
+        var c = v * s;
+        var h1 = h / 60;
+        var x = c * (1 - Math.abs(h1 % 2 - 1));
+        var m = v - c;
+        var rgb;
+        if (typeof h == 'undefined')
+          rgb = [
+            0,
+            0,
+            0
+          ];
+        else if (h1 < 1)
+          rgb = [
+            c,
+            x,
+            0
+          ];
+        else if (h1 < 2)
+          rgb = [
+            x,
+            c,
+            0
+          ];
+        else if (h1 < 3)
+          rgb = [
+            0,
+            c,
+            x
+          ];
+        else if (h1 < 4)
+          rgb = [
+            0,
+            x,
+            c
+          ];
+        else if (h1 < 5)
+          rgb = [
+            x,
+            0,
+            c
+          ];
+        else if (h1 <= 6)
+          rgb = [
+            c,
+            0,
+            x
+          ];
+        return [
+          255 * (rgb[0] + m),
+          255 * (rgb[1] + m),
+          255 * (rgb[2] + m)
+        ];
+      }
+      function hsl2rgb(h, s, l) {
         var r, g, b;
         h /= 360;
-        if(s == 0){
-            r = g = b = l; // achromatic
-        }else{
-            function hue2rgb(p, q, t){
-                if(t < 0) t += 1;
-                if(t > 1) t -= 1;
-                if(t < 1/6) return p + (q - p) * 6 * t;
-                if(t < 1/2) return q;
-                if(t < 2/3) return p + (q - p) * (2/3 - t) * 6;
-                return p;
+        if (s == 0) {
+          r = g = b = l;
+        } else
+          // achromatic
+          {
+            function hue2rgb(p, q, t) {
+              if (t < 0)
+                t += 1;
+              if (t > 1)
+                t -= 1;
+              if (t < 1 / 6)
+                return p + (q - p) * 6 * t;
+              if (t < 1 / 2)
+                return q;
+              if (t < 2 / 3)
+                return p + (q - p) * (2 / 3 - t) * 6;
+              return p;
             }
-    
             var q = l < 0.5 ? l * (1 + s) : l + s - l * s;
             var p = 2 * l - q;
-            r = hue2rgb(p, q, h + 1/3);
+            r = hue2rgb(p, q, h + 1 / 3);
             g = hue2rgb(p, q, h);
-            b = hue2rgb(p, q, h - 1/3);
-        }
-    
-        return [Math.round(r * 255), Math.round(g * 255), Math.round(b * 255)];
-    }
-    Polymer('paper-color-circle', {
-
-      publish: {
-        /**
-         * hsv OR hsl
-         *
-         * @attribute type
-         * @type string
-         * @default 'hsv'
-         */
-        type: 'hsv',
-        /**
-         * square, circle or huebox
-         *
-         * @attribute shape
-         * @type string
-         * @default 'circle'
-         */
-        shape: 'circle',
-        /**
-         * In case of hsl, the lightness
-         *
-         * @attribute lightness
-         * @type number
-         * @default .5
-         */
-        lightness:.5,
-        /**
-         * In case of hsv, the value
-         *
-         * @attribute value
-         * @type number
-         * @default 1
-         */
-        value:1,
-        /**
-         * In case of a huebox, the hue from 0 to 1
-         *
-         * @attribute value
-         * @type number
-         * @default 1
-         */
-        hue:0,
-        /**
-         * Picked color
-         *
-         * @attribute color
-         * @type Array
-         * @default new Array(2)
-         */
-        color: [],
-        /**
-         * A AA border can be drawn to prevent jagged edges on circles
-         *
-         * @attribute colouredAAborder
-         * @type boolean
-         * @default false
-         */
-        AAborder: true,
-        /**
-         * A coloured AA border can be drawn to prevent jagged edges on circles
-         *
-         * @attribute colouredAAborder
-         * @type Array
-         * @default false
-         */
-        colouredAAborder: false
-      },
-      _ctx:{},
-      _domReady:false,
-      _redrawTimer:0,
-      hsv2rgb:hsv2rgb,
-      hsl2rgb:hsl2rgb,
-      pickColor: function(e,redraw){
-        var rect = this.getBoundingClientRect();
-        var touchX = (e.clientX - rect.left);
-        var touchY = (e.clientY - rect.top);
-        var color = this._ctx.getImageData(touchX, touchY, 1, 1).data;
-        if(color[3] > 0) {
-          this.color = [color[0], color[1], color[2]];
-          if(redraw) this.redraw();
-        }
-      },
-      _setAAborder:undefined,
-      _moveStart:false,
-      _down:false,
-      onDown:function(e){
-        this._setAAborder = this.AAborder;
-        this.pickColor(e,true);
-        this._down = true;
-      },
-      onMove:function(e){
-        if(!this._moveStart){
-          if(this._setAAborder && this._down){
-            this.AAborder = false;
-            this.pickColor(e,true);
-          }else{
-            this.pickColor(e,false);
+            b = hue2rgb(p, q, h - 1 / 3);
           }
-          this._moveStart = true;
-        }else{
-          this.pickColor(e,false);
-        }
-        
-      },
-      onUp:function(e){
-        this._down = false;
-        if(this._moveStart){
-          if(this._setAAborder){
-            this.AAborder = this._setAAborder;
-            this.redraw();
+        return [
+          Math.round(r * 255),
+          Math.round(g * 255),
+          Math.round(b * 255)
+        ];
+      }
+      Polymer({
+        is: 'paper-color-circle',
+        properties: {
+          /**
+           * A AA border can be drawn to prevent jagged edges on circles
+           *
+           * @attribute colouredAAborder
+           * @type boolean
+           * @default false
+           */
+          AAborder: {
+            type: Boolean,
+            value: true,
+            notify: true
+          },
+          _ctx: {
+            type: Object,
+            value: function () {
+              return {};
+            }
+          },
+          _domReady: {
+            type: Boolean,
+            value: false
+          },
+          _down: {
+            type: Boolean,
+            value: false
+          },
+          _moveStart: {
+            type: Boolean,
+            value: false
+          },
+          _redrawTimer: {
+            type: Number,
+            value: 0
+          },
+          _setAAborder: {
+            value: function () {
+              return undefined;
+            }
+          },
+          /**
+           * Picked color
+           *
+           * @attribute color
+           * @type Array
+           * @default new Array(2)
+           */
+          color: {
+            type: Array,
+            value: function () {
+              return [];
+            },
+            notify: true,
+            observer: 'colorChanged'
+          },
+          /**
+           * A coloured AA border can be drawn to prevent jagged edges on circles
+           *
+           * @attribute colouredAAborder
+           * @type Array
+           * @default false
+           */
+          colouredAAborder: {
+            type: Boolean,
+            value: false,
+            notify: true
+          },
+          hsl2rgb: {
+            value: function () {
+              return hsl2rgb;
+            }
+          },
+          hsv2rgb: {
+            value: function () {
+              return hsv2rgb;
+            }
+          },
+          /**
+           * In case of a huebox, the hue from 0 to 1
+           *
+           * @attribute value
+           * @type number
+           * @default 1
+           */
+          hue: {
+            type: Number,
+            value: 0,
+            notify: true,
+            observer: 'hueChanged'
+          },
+          /**
+           * In case of hsl, the lightness
+           *
+           * @attribute lightness
+           * @type number
+           * @default .5
+           */
+          lightness: {
+            type: Number,
+            value: 0.5,
+            notify: true,
+            observer: 'lightnessChanged'
+          },
+          /**
+           * square, circle or huebox
+           *
+           * @attribute shape
+           * @type string
+           * @default 'circle'
+           */
+          shape: {
+            type: String,
+            value: 'circle',
+            notify: true
+          },
+          /**
+           * hsv OR hsl
+           *
+           * @attribute type
+           * @type string
+           * @default 'hsv'
+           */
+          type: {
+            type: String,
+            value: 'hsv',
+            notify: true
+          },
+          /**
+           * In case of hsv, the value
+           *
+           * @attribute value
+           * @type number
+           * @default 1
+           */
+          value: {
+            type: Number,
+            value: 1,
+            notify: true,
+            observer: 'valueChanged'
           }
-          this._moveStart = false;
-        }
-        this.$.ripple.style.color = "rgb("+this.color[0]+","+this.color[1]+","+this.color[2]+")";
-        this.$.ripple.downAction({x: e.x, y: e.y});
-        var that = this;
-        setTimeout(function(){
-          that.$.ripple.upAction();
-        },100);
-      },
-      redraw:function(){
-        var size = this.getBoundingClientRect();
-        var width = size.width;
-        var height = size.height;
-        if(width == 0 || height == 0){
-          var computedStyle = window.getComputedStyle(this);
-          width = parseInt(computedStyle.width);
-          height = parseInt(computedStyle.height);
-        }
-        this.$.canvas.width = width;
-        this.$.canvas.height = height;
-        this.size = Math.min(width,height);
-        var halfsize = this.size/2;
-        var bitmap = this._ctx.getImageData(0, 0, this.size, this.size);
-        var smoothBorder = 0;
-        for (var y = 0; y < this.size; y++) {
-          for (var x = 0; x < this.size; x++) {
-            
-            // offset for the 4 RGBA values in the data array
-            var offset = 4 * ((y * this.size) + x);
-            
-            if(this.shape == "circle"){
-              var distanceFromCenter = Math.sqrt(Math.pow(y - halfsize, 2) + Math.pow(x - halfsize, 2)) / halfsize;
-              if(distanceFromCenter < (halfsize+smoothBorder)/halfsize - 0.01){
+        },
+        pickColor: function (e, redraw) {
+          var rect = this.getBoundingClientRect();
+          var touchX = e.clientX - rect.left;
+          var touchY = e.clientY - rect.top;
+          var color = this._ctx.getImageData(touchX, touchY, 1, 1).data;
+          if (color[3] > 0) {
+            this.color = [
+              color[0],
+              color[1],
+              color[2]
+            ];
+            if (redraw)
+              this.redraw();
+          }
+        },
+        onDown: function (e) {
+          this._setAAborder = this.AAborder;
+          this.pickColor(e, true);
+          this._down = true;
+        },
+        onMove: function (e) {
+          if (!this._moveStart) {
+            if (this._setAAborder && this._down) {
+              this.AAborder = false;
+              this.pickColor(e, true);
+            } else {
+              this.pickColor(e, false);
+            }
+            this._moveStart = true;
+          } else {
+            this.pickColor(e, false);
+          }
+        },
+        onUp: function (e) {
+          this._down = false;
+          if (this._moveStart) {
+            if (this._setAAborder) {
+              this.AAborder = this._setAAborder;
+              this.redraw();
+            }
+            this._moveStart = false;
+          }
+          this.set('$.ripple.style.color', 'rgb(' + this.color[0] + ',' + this.color[1] + ',' + this.color[2] + ')');
+          this.$.ripple.downAction({
+            x: e.x,
+            y: e.y
+          });
+          var that = this;
+          setTimeout(function () {
+            that.$.ripple.upAction();
+          }, 100);
+        },
+        redraw: function () {
+          var size = this.getBoundingClientRect();
+          var width = size.width;
+          var height = size.height;
+          if (width == 0 || height == 0) {
+            var computedStyle = window.getComputedStyle(this);
+            width = parseInt(computedStyle.width);
+            height = parseInt(computedStyle.height);
+          }
+          this.set('$.canvas.width', width);
+          this.set('$.canvas.height', height);
+          this.size = Math.min(width, height);
+          var halfsize = this.size / 2;
+          var bitmap = this._ctx.getImageData(0, 0, this.size, this.size);
+          var smoothBorder = 0;
+          for (var y = 0; y < this.size; y++) {
+            for (var x = 0; x < this.size; x++) {
+              // offset for the 4 RGBA values in the data array
+              var offset = 4 * (y * this.size + x);
+              if (this.shape == 'circle') {
+                var distanceFromCenter = Math.sqrt(Math.pow(y - halfsize, 2) + Math.pow(x - halfsize, 2)) / halfsize;
+                if (distanceFromCenter < (halfsize + smoothBorder) / halfsize - 0.01) {
                   var hue = Math.atan2(y - halfsize, x - halfsize) * (180 / Math.PI);
-                  if(hue < 0) hue+=360;
-                  var saturation = Math.round(distanceFromCenter*1000)/1000;
+                  if (hue < 0)
+                    hue += 360;
+                  var saturation = Math.round(distanceFromCenter * 1000) / 1000;
                   saturation = Math.min(1, saturation);
-                  if(this.type == "hsv"){
-                      var value = Math.round(this.value*1000)/1000;
-                      var color = hsv2rgb(hue, saturation, value);
-                  }else if(this.type == "hsl"){
-                      var lightness = Math.round(this.lightness*1000)/1000;
-                      var color = hsl2rgb(hue, saturation, lightness);
+                  if (this.type == 'hsv') {
+                    var value = Math.round(this.value * 1000) / 1000;
+                    var color = hsv2rgb(hue, saturation, value);
+                  } else if (this.type == 'hsl') {
+                    var lightness = Math.round(this.lightness * 1000) / 1000;
+                    var color = hsl2rgb(hue, saturation, lightness);
                   }
-                      
                   // fill RGBA values
                   bitmap.data[offset + 0] = color[0];
                   bitmap.data[offset + 1] = color[1];
-                  bitmap.data[offset + 2] = color[2]; 
-                  if(distanceFromCenter - 1 >= 0){
-                    var distance = Math.round((distanceFromCenter - 1)*halfsize);
-                    
-                    bitmap.data[offset + 3] = 255*((smoothBorder-distance)/smoothBorder); // transparency
-                  }else{
-                    bitmap.data[offset + 3] = 255; // no transparency
-                  }
-              };
-            }else if(this.shape == "huebox"){
-              var saturation = x/width;
-              var hue = Math.round(this.hue*1000)/1000*360;
-              var third = 1-y/this.size;
-              if(this.type == "hsv"){
+                  bitmap.data[offset + 2] = color[2];
+                  if (distanceFromCenter - 1 >= 0) {
+                    var distance = Math.round((distanceFromCenter - 1) * halfsize);
+                    bitmap.data[offset + 3] = 255 * ((smoothBorder - distance) / smoothBorder);
+                  } else
+                    // transparency
+                    {
+                      bitmap.data[offset + 3] = 255;
+                    }
+                }
+                // no transparency
+                ;
+              } else if (this.shape == 'huebox') {
+                var saturation = x / width;
+                var hue = Math.round(this.hue * 1000) / 1000 * 360;
+                var third = 1 - y / this.size;
+                if (this.type == 'hsv') {
                   var color = hsv2rgb(hue, saturation, third);
-              }else if(this.type == "hsl"){
+                } else if (this.type == 'hsl') {
                   var color = hsl2rgb(hue, saturation, third);
-              }
-              bitmap.data[offset + 0] = color[0];
-              bitmap.data[offset + 1] = color[1];
-              bitmap.data[offset + 2] = color[2];
-              bitmap.data[offset + 3] = 255; // no transparency
-            }else if(this.shape == "square"){
-              var hue = x/width*360;
-              var saturation = 1-y/this.size;
-              if(this.type == "hsv"){
-                  var value = Math.round(this.value*1000)/1000;
+                }
+                bitmap.data[offset + 0] = color[0];
+                bitmap.data[offset + 1] = color[1];
+                bitmap.data[offset + 2] = color[2];
+                bitmap.data[offset + 3] = 255;
+              } else // no transparency
+              if (this.shape == 'square') {
+                var hue = x / width * 360;
+                var saturation = 1 - y / this.size;
+                if (this.type == 'hsv') {
+                  var value = Math.round(this.value * 1000) / 1000;
                   var color = hsv2rgb(hue, saturation, value);
-              }else if(this.type == "hsl"){
-                  var lightness = Math.round(this.lightness*1000)/1000;
+                } else if (this.type == 'hsl') {
+                  var lightness = Math.round(this.lightness * 1000) / 1000;
                   var color = hsl2rgb(hue, saturation, lightness);
+                }
+                bitmap.data[offset + 0] = color[0];
+                bitmap.data[offset + 1] = color[1];
+                bitmap.data[offset + 2] = color[2];
+                bitmap.data[offset + 3] = 255;
               }
-              bitmap.data[offset + 0] = color[0];
-              bitmap.data[offset + 1] = color[1];
-              bitmap.data[offset + 2] = color[2];
-              bitmap.data[offset + 3] = 255; // no transparency
             }
-            
-          };
-        };
-        this._ctx.putImageData(bitmap, 0, 0);
-        if(this.AAborder && this.shape == "circle"){
-          //Getting a nice anti aliased edge using canvas is hard, so instead a white circle is draw over the border
-          this.drawAACircle();
-        }
-      },
-      drawAACircle: function(){
-        if(this.colouredAAborder){
-          if(this.color[1]){
-            this._ctx.strokeStyle = "rgb("+this.color[0]+","+this.color[1]+","+this.color[2]+")";
-          }else{
-            this._ctx.strokeStyle = "rgb("+this.colouredAAborder[0]+","+this.colouredAAborder[1]+","+this.colouredAAborder[2]+")";
+            // no transparency
+            ;
           }
-        }else{
-          this._ctx.strokeStyle = "rgb(255,255,255)";
+          ;
+          this._ctx.putImageData(bitmap, 0, 0);
+          if (this.AAborder && this.shape == 'circle') {
+            //Getting a nice anti aliased edge using canvas is hard, so instead a white circle is draw over the border
+            this.drawAACircle();
+          }
+        },
+        drawAACircle: function () {
+          if (this.colouredAAborder) {
+            if (this.color[1]) {
+              this.set('_ctx.strokeStyle', 'rgb(' + this.color[0] + ',' + this.color[1] + ',' + this.color[2] + ')');
+            } else {
+              this.set('_ctx.strokeStyle', 'rgb(' + this.colouredAAborder[0] + ',' + this.colouredAAborder[1] + ',' + this.colouredAAborder[2] + ')');
+            }
+          } else {
+            this.set('_ctx.strokeStyle', 'rgb(255,255,255)');
+          }
+          this.set('_ctx.lineWidth', 2);
+          this._ctx.beginPath();
+          var borderRadius = this.size / 2;
+          this._ctx.arc(this.size / 2, this.size / 2, borderRadius - 1, 0, 2 * Math.PI, false);
+          this._ctx.closePath();
+          this._ctx.stroke();
+        },
+        valueChanged: function () {
+          if (this._domReady)
+            this.redraw();
+        },
+        lightnessChanged: function () {
+          if (this._domReady)
+            this.redraw();
+        },
+        hueChanged: function () {
+          if (this._domReady)
+            this.redraw();
+        },
+        colorChanged: function () {
+          if (this._domReady)
+            this.redraw();
+        },
+        ready: function () {
+          this._domReady = true;
+          this._ctx = this.$.canvas.getContext('2d');
+          this.redraw();
         }
-        this._ctx.lineWidth = 2;
-        this._ctx.beginPath();
-        var borderRadius = this.size/2;
-        this._ctx.arc(this.size/2, this.size/2, borderRadius-1, 0, 2*Math.PI, false);
-        this._ctx.closePath();
-        this._ctx.stroke();
-      },
-      valueChanged:function(){
-        if(this._domReady) this.redraw();
-      },
-      lightnessChanged:function(){
-        if(this._domReady) this.redraw();
-      },
-      hueChanged:function(){
-        if(this._domReady) this.redraw();
-      },
-      colorChanged:function(){
-        if(this._domReady) this.redraw();
-      },
-      domReady:function(){
-        this._domReady = true;
-        this._ctx = this.$.canvas.getContext("2d");
-        this.redraw();
-      }
-
-    });
-
-  })();
-
-</script>
-
-</polymer-element>
+      });
+    }());
+  </script>
+</dom-module>

--- a/paper-color-circle.html
+++ b/paper-color-circle.html
@@ -260,8 +260,8 @@
         },
         pickColor: function (e, redraw) {
           var rect = this.getBoundingClientRect();
-          var touchX = e.clientX - rect.left;
-          var touchY = e.clientY - rect.top;
+          var touchX = e.detail.x - rect.left;
+          var touchY = e.detail.y - rect.top;
           var color = this._ctx.getImageData(touchX, touchY, 1, 1).data;
           if (color[3] > 0) {
             this.color = [

--- a/paper-color-circle.html
+++ b/paper-color-circle.html
@@ -23,7 +23,7 @@
     }
   </style>
   <template>
-  <paper-ripple id="ripple" class$="{{shape}}"></paper-ripple>
+  <paper-ripple id="ripple" class$="{{shape}}" recenters></paper-ripple>
   <canvas id="canvas" on-down="onDown" on-up="onUp" on-track="onMove"></canvas>
 </template>
   <script>
@@ -301,14 +301,6 @@
             this._moveStart = false;
           }
           this.set('$.ripple.style.color', 'rgb(' + this.color[0] + ',' + this.color[1] + ',' + this.color[2] + ')');
-          this.$.ripple.downAction({
-            x: e.x,
-            y: e.y
-          });
-          var that = this;
-          setTimeout(function () {
-            that.$.ripple.upAction();
-          }, 100);
         },
         redraw: function () {
           var size = this.getBoundingClientRect();

--- a/paper-color-circle.html
+++ b/paper-color-circle.html
@@ -1,5 +1,5 @@
-<link href="../polymer/polymer.html" rel="import">
-<link href="../paper-ripple/paper-ripple.html" rel="import">
+<link href="bower_components/polymer/polymer.html" rel="import">
+<link href="bower_components/paper-ripple/paper-ripple.html" rel="import">
 
 <dom-module id="paper-color-circle">
   <style>

--- a/paper-color-picker.html
+++ b/paper-color-picker.html
@@ -140,16 +140,16 @@ There are three different main configurations the dialog allows, `circle`, `squa
         
         <template is="dom-if" if="{{_computeIf(shape, type)}}">
           <label>Value (Brightness):</label><br>
-          <paper-slider id="valueSlider" min="0" max="100" pin="true" value="100" immediatevalue="{{sliderValue}}"></paper-slider>
+          <paper-slider id="valueSlider" min="0" max="100" pin="true" value="100" immediate-value="{{sliderValue}}"></paper-slider>
         </template>
         <template is="dom-if" if="{{_computeIf2(shape, type)}}">
           <label>Lightness:</label><br>
-          <paper-slider id="lightnessSlider" min="0" max="100" pin="true" value="50" immediatevalue="{{sliderLightness}}"></paper-slider>
+          <paper-slider id="lightnessSlider" min="0" max="100" pin="true" value="50" immediate-value="{{sliderLightness}}"></paper-slider>
         </template>
         <template is="dom-if" if="{{_computeIf3(shape)}}">
           <label>Hue:</label><br>
           <canvas id="huePicker" on-tap="huePickerPickColor" width="360" height="1"></canvas>
-          <!--<paper-slider id="hueSlider" min="0" max="100" value="50" immediateValue="{{sliderHue}}"></paper-slider>-->
+          <!--<paper-slider id="hueSlider" min="0" max="100" value="50" immediate-value="{{sliderHue}}"></paper-slider>-->
         </template>
         
         <div class="landscapeOnly">
@@ -272,11 +272,13 @@ There are three different main configurations the dialog allows, `circle`, `squa
         }
       },
       setColorWheel: function () {
+        var valueSlider = document.querySelector('#valueSlider');
+        var lightnessSlider = document.querySelector('#lightnessSlider');
         if (!this.disableUpdate) {
-          if (this.$.valueSlider)
-            this.colorValue = this.$.valueSlider.immediateValue / 100;
-          if (this.$.lightnessSlider)
-            this.colorLightness = this.$.lightnessSlider.immediateValue / 100;
+          if (valueSlider)
+            this.colorValue = valueSlider.immediateValue / 100;
+          if (lightnessSlider)
+            this.colorLightness = lightnessSlider.immediateValue / 100;
           that = this;
           setTimeout(function () {
             that.disableUpdate = false;

--- a/paper-color-picker.html
+++ b/paper-color-picker.html
@@ -1,8 +1,6 @@
 <!--
 Copyright (c) 2014 David Mulder
--->
-
-<!--
+--><!--
 
 Material Design: Color picker inspired by <a href="http://www.google.com/design/spec/components/pickers.html">Material Design Pickers</a>
 
@@ -27,8 +25,7 @@ There are three different main configurations the dialog allows, `circle`, `squa
 @group Paper Elements
 @element paper-color-picker
 @homepage github.io
--->
-<link href="../polymer/polymer.html" rel="import">
+--><html><head><link href="../polymer/polymer.html" rel="import">
 <link href="../paper-slider/paper-slider.html" rel="import">
 <link href="../paper-dialog/paper-action-dialog.html" rel="import">
 <link href="../paper-button/paper-button.html" rel="import">
@@ -113,82 +110,108 @@ There are three different main configurations the dialog allows, `circle`, `squa
   }
   
 </style>
-<polymer-element name="paper-color-picker">
-
-<template>
-
+  <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
+<dom-module id="paper-color-picker">
+  <style>
+    /* TODO(polyup): For speed, consider reworking these styles with .classes
+                     and #ids rather than [attributes].
+    */
+    [layout] {
+      @apply(--layout);
+    }
+    [layout][vertical] {
+      @apply(--layout-vertical);
+    }
+  </style>
   <style>
     :host {
     }
   </style>
+  <template>
 
-  <paper-action-dialog id="dialog" class="color-picker-dialog" backdrop>
-    <div id="container" layout vertical>
+  <paper-action-dialog id="dialog" class="color-picker-dialog" backdrop="">
+    <div id="container" layout="" vertical="">
       <div id="header">
         <div id="title">Color Picker</div>
         <div id="preview">
-          <paper-color-circle id="picker" colouredAAborder="{{[50,50,50]}}" shape="{{shape}}" type="{{type}}" value="{{colorValue}}" color="{{immediateColor}}" hue="{{colorHue}}" lightness="{{colorLightness}}"></paper-color-circle>
+          <paper-color-circle id="picker" colouredaaborder="{{_computeColouredaaborder()}}" shape="{{shape}}" type="{{type}}" value="{{colorValue}}" color="{{immediateColor}}" hue="{{colorHue}}" lightness="{{colorLightness}}"></paper-color-circle>
         </div>
       </div>
       <div id="detail">
         
-        <template if="{{type == 'hsv' && shape !== 'huebox'}}">
-          <label>Value (Brightness):</label><br/>
-          <paper-slider id="valueSlider" min="0" max="100" pin="true" value="100" immediateValue="{{sliderValue}}"></paper-slider>
+        <template is="dom-if" if="{{_computeIf(shape, type)}}">
+          <label>Value (Brightness):</label><br>
+          <paper-slider id="valueSlider" min="0" max="100" pin="true" value="100" immediatevalue="{{sliderValue}}"></paper-slider>
         </template>
-        <template if="{{type == 'hsl' && shape !== 'huebox'}}">
-          <label>Lightness:</label><br/>
-          <paper-slider id="lightnessSlider" min="0" max="100" pin="true" value="50" immediateValue="{{sliderLightness}}"></paper-slider>
+        <template is="dom-if" if="{{_computeIf2(shape, type)}}">
+          <label>Lightness:</label><br>
+          <paper-slider id="lightnessSlider" min="0" max="100" pin="true" value="50" immediatevalue="{{sliderLightness}}"></paper-slider>
         </template>
-        <template if="{{shape == 'huebox'}}">
-          <label>Hue:</label><br/>
-          <canvas id="huePicker" on-tap="{{huePickerPickColor}}" width="360" height="1"></canvas>
+        <template is="dom-if" if="{{_computeIf3(shape)}}">
+          <label>Hue:</label><br>
+          <canvas id="huePicker" on-tap="huePickerPickColor" width="360" height="1"></canvas>
           <!--<paper-slider id="hueSlider" min="0" max="100" value="50" immediateValue="{{sliderHue}}"></paper-slider>-->
         </template>
         
         <div class="landscapeOnly">
-          <label>Red:</label><br/>
+          <label>Red:</label><br>
           <paper-input value="{{immediateColor[0]}}" type="number" min="0" max="255"></paper-input>
         </div>
         <div class="landscapeOnly">
-          <label>Green:</label><br/>
+          <label>Green:</label><br>
           <paper-input value="{{immediateColor[1]}}" type="number" min="0" max="255"></paper-input>
         </div>
         <div class="landscapeOnly">
-          <label>Blue:</label><br/>
+          <label>Blue:</label><br>
           <paper-input value="{{immediateColor[2]}}" type="number" min="0" max="255"></paper-input>
         </div>
         
       </div>
     </div>
-    <paper-button affirmative>Cancel</paper-button>
-    <paper-button affirmative on-tap="{{setColor}}">OK</paper-button>
+    <paper-button affirmative="">Cancel</paper-button>
+    <paper-button affirmative="" on-tap="setColor">OK</paper-button>
 
   </paper-action-dialog>
 </template>
-
-<script>
-
-  Polymer('paper-color-picker', {
-
-    publish: {
-      /**
-         * *hsv* or *hsl*
+  <script>
+    Polymer({
+      is: 'paper-color-picker',
+      properties: {
+        /**
+         * The selected color as an array: `[red, green, blue]`
          *
-         * @attribute type
-         * @type string
-         * @default 'hsv'
+         * @attribute color
+         * @type Array
+         * @default new Array(3)
          */
-      type:"hsv",
-      /**
-         * *square*, *circle* or *huebox*
-         *
-         * @attribute shape
-         * @type string
-         * @default 'circle'
-         */
-      shape:"circle",
-      /**
+        color: {
+          type: Array,
+          value: function () {
+            return [
+              undefined,
+              undefined,
+              undefined
+            ];
+          },
+          notify: true
+        },
+        colorHue: {
+          type: Number,
+          value: 0
+        },
+        colorLightness: {
+          type: Number,
+          value: 0.5
+        },
+        colorValue: {
+          type: Number,
+          value: 1
+        },
+        disableUpdate: {
+          type: Boolean,
+          value: false
+        },
+        /**
          * The selected color as an array: `[red, green, blue]`
          * even before the user clicks ok
          *
@@ -196,84 +219,126 @@ There are three different main configurations the dialog allows, `circle`, `squa
          * @type Array
          * @default new Array(3)
          */
-      immediateColor:[50,50,50],
-      /**
-         * The selected color as an array: `[red, green, blue]`
+        immediateColor: {
+          type: Array,
+          value: function () {
+            return [
+              50,
+              50,
+              50
+            ];
+          },
+          notify: true,
+          observer: 'immediateColorChanged'
+        },
+        /**
+         * *square*, *circle* or *huebox*
          *
-         * @attribute color
-         * @type Array
-         * @default new Array(3)
+         * @attribute shape
+         * @type string
+         * @default 'circle'
          */
-      color:[undefined, undefined, undefined]
-    },
-    
-    colorValue:1,
-    colorLightness:.5,
-    colorHue:0,
-    disableUpdate:false,
-    sliderValue:100,
-    sliderLightness:50,
-    sliderHue:50,
-    
-    setColorWheel: function(){
-      if(!this.disableUpdate){
-        if(this.$.valueSlider) this.colorValue = this.$.valueSlider.immediateValue/100;
-        if(this.$.lightnessSlider) this.colorLightness = this.$.lightnessSlider.immediateValue/100;
-        that = this;
-        setTimeout(function(){
-          that.disableUpdate = false;
-        }, 50);
+        shape: {
+          type: String,
+          value: 'circle',
+          notify: true
+        },
+        sliderHue: {
+          type: Number,
+          value: 50
+        },
+        sliderLightness: {
+          type: Number,
+          value: 50,
+          observer: 'sliderLightnessChanged'
+        },
+        sliderValue: {
+          type: Number,
+          value: 100,
+          observer: 'sliderValueChanged'
+        },
+        /**
+         * *hsv* or *hsl*
+         *
+         * @attribute type
+         * @type string
+         * @default 'hsv'
+         */
+        type: {
+          type: String,
+          value: 'hsv',
+          notify: true
+        }
+      },
+      setColorWheel: function () {
+        if (!this.disableUpdate) {
+          if (this.$.valueSlider)
+            this.colorValue = this.$.valueSlider.immediateValue / 100;
+          if (this.$.lightnessSlider)
+            this.colorLightness = this.$.lightnessSlider.immediateValue / 100;
+          that = this;
+          setTimeout(function () {
+            that.disableUpdate = false;
+          }, 50);
+        }
+        this.disableUpdate = true;
+      },
+      sliderValueChanged: function () {
+        this.setColorWheel();
+      },
+      sliderLightnessChanged: function () {
+        this.setColorWheel();
+      },
+      immediateColorChanged: function () {
+        this.set('$.preview.style.backgroundColor', 'rgb(' + this.immediateColor[0] + ',' + this.immediateColor[1] + ',' + this.immediateColor[2] + ')');
+        var maxZ = Math.max.bind(Math, 0);
+        this.set('$.title.style.backgroundColor', 'rgb(' + maxZ(this.immediateColor[0] - 40) + ',' + maxZ(this.immediateColor[1] - 40) + ',' + maxZ(this.immediateColor[2] - 40) + ')');
+      },
+      drawHuePicker: function () {
+        this._huePickerCtx = this.$.huePicker.getContext('2d');
+        var bitmap = this._huePickerCtx.getImageData(0, 0, 360, 30);
+        for (var x = 0; x < 360; x++) {
+          var hue = x;
+          var color = this.$.picker.hsv2rgb(hue, 1, 1);
+          bitmap.data[4 * x + 0] = color[0];
+          bitmap.data[4 * x + 1] = color[1];
+          bitmap.data[4 * x + 2] = color[2];
+          bitmap.data[4 * x + 3] = 255;
+        }
+        this._huePickerCtx.putImageData(bitmap, 0, 0);
+      },
+      huePickerPickColor: function (e) {
+        var rect = this.$.huePicker.getBoundingClientRect();
+        var percentage = (e.x - rect.left) / rect.width;
+        this.colorHue = percentage;
+      },
+      setColor: function () {
+        this.color = this.immediateColor;
+      },
+      open: function () {
+        if (this.color && this.color[1])
+          this.immediateColor = this.color;
+        this.immediateColorChanged();
+        this.$.dialog.open();
+        if (this.$.huePicker)
+          this.drawHuePicker();
+      },
+      _computeColouredaaborder: function () {
+        return [
+          50,
+          50,
+          50
+        ];
+      },
+      _computeIf: function (shape, type) {
+        return type == 'hsv' && shape !== 'huebox';
+      },
+      _computeIf2: function (shape, type) {
+        return type == 'hsl' && shape !== 'huebox';
+      },
+      _computeIf3: function (shape) {
+        return shape == 'huebox';
       }
-      this.disableUpdate = true;
-    },
-    
-    sliderValueChanged: function(){
-      this.setColorWheel();
-    },
-    
-    sliderLightnessChanged: function(){
-      this.setColorWheel();
-    },
-    
-    immediateColorChanged: function(){
-      this.$.preview.style.backgroundColor = "rgb("+this.immediateColor[0]+","+this.immediateColor[1]+","+this.immediateColor[2]+")";
-      var maxZ = Math.max.bind(Math, 0);
-      this.$.title.style.backgroundColor = "rgb("+maxZ(this.immediateColor[0]-40)+","+maxZ(this.immediateColor[1]-40)+","+maxZ(this.immediateColor[2]-40)+")";
-    },
-    
-    drawHuePicker: function(){
-      this._huePickerCtx = this.$.huePicker.getContext("2d");
-      var bitmap = this._huePickerCtx.getImageData(0, 0, 360, 30);
-      for (var x = 0; x < 360; x++) {
-        var hue = x;
-        var color = this.$.picker.hsv2rgb(hue,1,1);
-        bitmap.data[4 * x + 0] = color[0];
-        bitmap.data[4 * x + 1] = color[1];
-        bitmap.data[4 * x + 2] = color[2];
-        bitmap.data[4 * x + 3] = 255;
-      }
-      this._huePickerCtx.putImageData(bitmap, 0, 0);
-    },
-    
-    huePickerPickColor: function(e){
-      var rect = this.$.huePicker.getBoundingClientRect();
-      var percentage = (e.x - rect.left)/rect.width;
-      this.colorHue = percentage;
-    },
-    
-    setColor: function(){
-      this.color = this.immediateColor;
-    },
-    
-    open: function(){
-      if(this.color && this.color[1]) this.immediateColor = this.color;
-      this.immediateColorChanged();
-      this.$.dialog.open();
-      if(this.$.huePicker) this.drawHuePicker();
-    }
-
-  });
-
-</script>
-
-</polymer-element>
+    });
+  </script>
+</dom-module>

--- a/paper-color-picker.html
+++ b/paper-color-picker.html
@@ -29,8 +29,9 @@ There are three different main configurations the dialog allows, `circle`, `squa
 <html>
 <head>
 <link href="bower_components/polymer/polymer.html" rel="import">
+<link href="bower_components/iron-flex-layout/iron-flex-layout.html" rel="import">
 <link href="bower_components/paper-slider/paper-slider.html" rel="import">
-<link href="bower_components/paper-dialog/paper-action-dialog.html" rel="import">
+<link href="bower_components/paper-dialog/paper-dialog.html" rel="import">
 <link href="bower_components/paper-button/paper-button.html" rel="import">
 <link href="bower_components/paper-input/paper-input.html" rel="import">
 <link href="paper-color-circle.html" rel="import">
@@ -113,7 +114,6 @@ There are three different main configurations the dialog allows, `circle`, `squa
   }
   
 </style>
-  <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 <dom-module id="paper-color-picker">
   <style>
   </style>

--- a/paper-color-picker.html
+++ b/paper-color-picker.html
@@ -25,11 +25,11 @@ There are three different main configurations the dialog allows, `circle`, `squa
 @group Paper Elements
 @element paper-color-picker
 @homepage github.io
---><html><head><link href="../polymer/polymer.html" rel="import">
-<link href="../paper-slider/paper-slider.html" rel="import">
-<link href="../paper-dialog/paper-action-dialog.html" rel="import">
-<link href="../paper-button/paper-button.html" rel="import">
-<link href="../paper-input/paper-input.html" rel="import">
+--><html><head><link href="bower_components/polymer/polymer.html" rel="import">
+<link href="bower_components/paper-slider/paper-slider.html" rel="import">
+<link href="bower_components/paper-dialog/paper-action-dialog.html" rel="import">
+<link href="bower_components/paper-button/paper-button.html" rel="import">
+<link href="bower_components/paper-input/paper-input.html" rel="import">
 <link href="paper-color-circle.html" rel="import">
 
 <style>

--- a/paper-color-picker.html
+++ b/paper-color-picker.html
@@ -154,15 +154,15 @@ There are three different main configurations the dialog allows, `circle`, `squa
         
         <div class="landscapeOnly">
           <label>Red:</label><br>
-          <paper-input value="{{immediateColor[0]}}" type="number" min="0" max="255"></paper-input>
+          <paper-input value="{{immediateColor.0}}" type="number" min="0" max="255"></paper-input>
         </div>
         <div class="landscapeOnly">
           <label>Green:</label><br>
-          <paper-input value="{{immediateColor[1]}}" type="number" min="0" max="255"></paper-input>
+          <paper-input value="{{immediateColor.1}}" type="number" min="0" max="255"></paper-input>
         </div>
         <div class="landscapeOnly">
           <label>Blue:</label><br>
-          <paper-input value="{{immediateColor[2]}}" type="number" min="0" max="255"></paper-input>
+          <paper-input value="{{immediateColor.2}}" type="number" min="0" max="255"></paper-input>
         </div>
         
       </div>

--- a/paper-color-picker.html
+++ b/paper-color-picker.html
@@ -116,15 +116,6 @@ There are three different main configurations the dialog allows, `circle`, `squa
   <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 <dom-module id="paper-color-picker">
   <style>
-    /* TODO(polyup): For speed, consider reworking these styles with .classes
-                     and #ids rather than [attributes].
-    */
-    [layout] {
-      @apply(--layout);
-    }
-    [layout][vertical] {
-      @apply(--layout-vertical);
-    }
   </style>
   <style>
     :host {

--- a/paper-color-picker.html
+++ b/paper-color-picker.html
@@ -47,84 +47,78 @@ There are three different main configurations the dialog allows, `circle`, `squa
     
     padding:0px;
   }
-  
-  html /deep/ .color-picker-dialog paper-color-circle {
-    width:200px;
-    height:200px;
-  }
-  
-  html /deep/ .color-picker-dialog #container {
-    /*position:absolute;
-    left:0px;
-    top:0px;
-    right:0px;
-    bottom:0px;*/
-  }
-  
-  html /deep/ .color-picker-dialog #preview {
-    padding:20px;
-    text-align:center;
-  }
-  
-  html /deep/ .color-picker-dialog #title {
-    text-align:center;
-    font-family: RobotoDraft, 'Helvetica Neue', Helvetica, Arial;
-    color:white;
-    padding:8px;
-    font-size:13px;
-  }
-  
-  html /deep/ .color-picker-dialog #detail {
-    padding:20px;
-    flex:1;
-  }
-  
-  html /deep/ .color-picker-dialog paper-slider {
-    width:100%;
-  }
-  html /deep/ .color-picker-dialog paper-input {
-    width:100%;
-    padding:0px 24px;
-    box-sizing:border-box;
-    margin:-10px 0px 0px 0px;
-  }
-  html /deep/ .color-picker-dialog #huePicker{
-    width:calc(100% - 30px);
-    margin:15px;
-    height:15px;
-    border-radius:2px;
-  }
-  html /deep/ .color-picker-dialog .landscapeOnly, html /deep/ .color-picker-dialog .portraitOnly{
-    display:none;
-  }
-  
-  @media only screen and (orientation : portrait) {
-    html /deep/ .color-picker-dialog .portraitOnly{
-      display:block;
-    }
-  }
-  @media only screen and (orientation : landscape) {
-    html /deep/ .color-picker-dialog #detail {
-      padding-top:35px;
-    }
-    html /deep/ .color-picker-dialog {
-      width:480px;
-    }
-    html /deep/ .color-picker-dialog #container {
-      display:flex;
-      flex-direction: row;
-    }
-    html /deep/ .color-picker-dialog .landscapeOnly{
-      display:block;
-    }
-  }
-  
 </style>
 <dom-module id="paper-color-picker">
   <style>
-  </style>
-  <style>
-    :host {
+    paper-color-circle {
+      width:200px;
+      height:200px;
+    }
+    
+    #container {
+      /*position:absolute;
+      left:0px;
+      top:0px;
+      right:0px;
+      bottom:0px;*/
+    }
+    
+    #preview {
+      padding:20px;
+      text-align:center;
+    }
+    
+    #title {
+      text-align:center;
+      font-family: RobotoDraft, 'Helvetica Neue', Helvetica, Arial;
+      color:white;
+      padding:8px;
+      font-size:13px;
+    }
+    
+    #detail {
+      padding:20px;
+      flex:1;
+    }
+    
+    paper-slider {
+      width:100%;
+    }
+    paper-input {
+      width:100%;
+      padding:0px 24px;
+      box-sizing:border-box;
+      margin:-10px 0px 0px 0px;
+    }
+    #huePicker{
+      width:calc(100% - 30px);
+      margin:15px;
+      height:15px;
+      border-radius:2px;
+    }
+    .landscapeOnly, .portraitOnly{
+      display:none;
+    }
+    
+    @media only screen and (orientation : portrait) {
+      .portraitOnly{
+        display:block;
+      }
+    }
+    @media only screen and (orientation : landscape) {
+      #detail {
+        padding-top:35px;
+      }
+      :host {
+        width:480px;
+      }
+      #container {
+        display:flex;
+        flex-direction: row;
+      }
+      .landscapeOnly{
+        display:block;
+      }
     }
   </style>
   <template>

--- a/paper-color-picker.html
+++ b/paper-color-picker.html
@@ -25,7 +25,10 @@ There are three different main configurations the dialog allows, `circle`, `squa
 @group Paper Elements
 @element paper-color-picker
 @homepage github.io
---><html><head><link href="bower_components/polymer/polymer.html" rel="import">
+-->
+<html>
+<head>
+<link href="bower_components/polymer/polymer.html" rel="import">
 <link href="bower_components/paper-slider/paper-slider.html" rel="import">
 <link href="bower_components/paper-dialog/paper-action-dialog.html" rel="import">
 <link href="bower_components/paper-button/paper-button.html" rel="import">
@@ -129,8 +132,8 @@ There are three different main configurations the dialog allows, `circle`, `squa
   </style>
   <template>
 
-  <paper-action-dialog id="dialog" class="color-picker-dialog" backdrop="">
-    <div id="container" layout="" vertical="">
+  <paper-dialog id="dialog" class="color-picker-dialog">
+    <div id="container" class="layout vertical">
       <div id="header">
         <div id="title">Color Picker</div>
         <div id="preview">
@@ -168,10 +171,12 @@ There are three different main configurations the dialog allows, `circle`, `squa
         
       </div>
     </div>
-    <paper-button affirmative="">Cancel</paper-button>
-    <paper-button affirmative="" on-tap="setColor">OK</paper-button>
+    <div class="buttons">
+      <paper-button dialog-dismiss>Cancel</paper-button>
+      <paper-button dialog-confirm on-tap="setColor">OK</paper-button>
+    </div>
 
-  </paper-action-dialog>
+  </paper-dialog>
 </template>
   <script>
     Polymer({

--- a/paper-color-picker.html
+++ b/paper-color-picker.html
@@ -32,14 +32,14 @@ There are three different main configurations the dialog allows, `circle`, `squa
 -->
 <html>
 <head>
-<link href="bower_components/polymer/polymer.html" rel="import">
-<link href="bower_components/iron-flex-layout/iron-flex-layout.html" rel="import">
-<link href="bower_components/paper-slider/paper-slider.html" rel="import">
-<link href="bower_components/paper-dialog/paper-dialog.html" rel="import">
-<link href="bower_components/paper-button/paper-button.html" rel="import">
-<link href="bower_components/paper-input/paper-input.html" rel="import">
-<link rel="import" href="bower_components/neon-animation/animations/fade-out-animation.html">
-<link rel="import" href="bower_components/neon-animation/animations/scale-up-animation.html">
+<link href="../polymer/polymer.html" rel="import">
+<link href="../iron-flex-layout/iron-flex-layout.html" rel="import">
+<link href="../paper-slider/paper-slider.html" rel="import">
+<link href="../paper-dialog/paper-dialog.html" rel="import">
+<link href="../paper-button/paper-button.html" rel="import">
+<link href="../paper-input/paper-input.html" rel="import">
+<link href="../neon-animation/animations/fade-out-animation.html" rel="import">
+<link href="../neon-animation/animations/scale-up-animation.html" rel="import">
 <link href="paper-color-circle.html" rel="import">
 
 <style>

--- a/paper-color-picker.html
+++ b/paper-color-picker.html
@@ -34,6 +34,8 @@ There are three different main configurations the dialog allows, `circle`, `squa
 <link href="bower_components/paper-dialog/paper-dialog.html" rel="import">
 <link href="bower_components/paper-button/paper-button.html" rel="import">
 <link href="bower_components/paper-input/paper-input.html" rel="import">
+<link rel="import" href="bower_components/neon-animation/animations/fade-out-animation.html">
+<link rel="import" href="bower_components/neon-animation/animations/scale-up-animation.html">
 <link href="paper-color-circle.html" rel="import">
 
 <style>
@@ -123,7 +125,10 @@ There are three different main configurations the dialog allows, `circle`, `squa
   </style>
   <template>
 
-  <paper-dialog id="dialog" class="color-picker-dialog">
+  <paper-dialog id="dialog" 
+                entry-animation="scale-up-animation"
+                exit-animation="fade-out-animation"
+                class="color-picker-dialog">
     <div id="container" class="layout vertical">
       <div id="header">
         <div id="title">Color Picker</div>

--- a/paper-color-picker.html
+++ b/paper-color-picker.html
@@ -158,15 +158,15 @@ There are three different main configurations the dialog allows, `circle`, `squa
         
         <div class="landscapeOnly">
           <label>Red:</label><br>
-          <paper-input id="redField" value="{{immediateColor.0}}" on-input="changeColorMixture" type="number" min="0" max="255"></paper-input>
+          <paper-input id="redField" value="{{immediateColor.red}}" on-input="changeColorMixture" type="number" min="0" max="255"></paper-input>
         </div>
         <div class="landscapeOnly">
           <label>Green:</label><br>
-          <paper-input id="greenField" value="{{immediateColor.1}}" on-input="changeColorMixture" type="number" min="0" max="255"></paper-input>
+          <paper-input id="greenField" value="{{immediateColor.green}}" on-input="changeColorMixture" type="number" min="0" max="255"></paper-input>
         </div>
         <div class="landscapeOnly">
           <label>Blue:</label><br>
-          <paper-input id="blueField" value="{{immediateColor.2}}" on-input="changeColorMixture" type="number" min="0" max="255"></paper-input>
+          <paper-input id="blueField" value="{{immediateColor.blue}}" on-input="changeColorMixture" type="number" min="0" max="255"></paper-input>
         </div>
         
       </div>
@@ -183,20 +183,18 @@ There are three different main configurations the dialog allows, `circle`, `squa
       is: 'paper-color-picker',
       properties: {
         /**
-         * The selected color as an array: `[red, green, blue]`
+         * The selected color as an object: `{red, green, blue}`
          *
          * @attribute color
-         * @type Array
-         * @default new Array(3)
+         * @type Object
+         * @default new Object()
          */
         color: {
-          type: Array,
-          value: function () {
-            return [
-              undefined,
-              undefined,
-              undefined
-            ];
+          type: Object,
+          value: {
+              red: undefined,
+              green: undefined,
+              blue: undefined
           },
           notify: true
         },
@@ -217,21 +215,19 @@ There are three different main configurations the dialog allows, `circle`, `squa
           value: false
         },
         /**
-         * The selected color as an array: `[red, green, blue]`
+         * The selected color as an object: `{red, green, blue}`
          * even before the user clicks ok
          *
          * @attribute immediateColor
-         * @type Array
-         * @default new Array(3)
+         * @type Object
+         * @default {red: 50, green: 50, blue: 50}
          */
         immediateColor: {
-          type: Array,
-          value: function () {
-            return [
-              50,
-              50,
-              50
-            ];
+          type: Object,
+          value: {
+              red: 50,
+              green: 50,
+              blue: 50
           },
           notify: true,
           observer: 'immediateColorChanged'
@@ -297,9 +293,9 @@ There are three different main configurations the dialog allows, `circle`, `squa
         this.setColorWheel();
       },
       immediateColorChanged: function () {
-        this.set('$.preview.style.backgroundColor', 'rgb(' + this.immediateColor[0] + ',' + this.immediateColor[1] + ',' + this.immediateColor[2] + ')');
+        this.set('$.preview.style.backgroundColor', 'rgb(' + this.immediateColor['red'] + ',' + this.immediateColor['green'] + ',' + this.immediateColor['blue'] + ')');
         var maxZ = Math.max.bind(Math, 0);
-        this.set('$.title.style.backgroundColor', 'rgb(' + maxZ(this.immediateColor[0] - 40) + ',' + maxZ(this.immediateColor[1] - 40) + ',' + maxZ(this.immediateColor[2] - 40) + ')');
+        this.set('$.title.style.backgroundColor', 'rgb(' + maxZ(this.immediateColor['red'] - 40) + ',' + maxZ(this.immediateColor['green'] - 40) + ',' + maxZ(this.immediateColor['blue'] - 40) + ')');
       },
       drawHuePicker: function () {
         this._huePickerCtx = this.$.huePicker.getContext('2d');
@@ -323,14 +319,18 @@ There are three different main configurations the dialog allows, `circle`, `squa
         var red = this.$.redField.value;
         var green = this.$.greenField.value;
         var blue = this.$.blueField.value;
-        var colors = [red, green, blue];
+        var colors = {
+          red: red,
+          green: green,
+          blue: blue
+        };
         this.set('immediateColor', colors);
       },
       setColor: function () {
         this.color = this.immediateColor;
       },
       open: function () {
-        if (this.color && this.color[1])
+        if (this.color && this.color['green'])
           this.immediateColor = this.color;
         this.immediateColorChanged();
         this.$.dialog.open();

--- a/paper-color-picker.html
+++ b/paper-color-picker.html
@@ -14,6 +14,10 @@ and to open the dialog
 
     this.$.picker.open();
 
+Demo
+---
+For a complete demo click here: <a href="demo/demo.html">Demo</a>
+
 Shape and colours
 ---
 There are three different main configurations the dialog allows, `circle`, `square`

--- a/paper-color-picker.html
+++ b/paper-color-picker.html
@@ -154,15 +154,15 @@ There are three different main configurations the dialog allows, `circle`, `squa
         
         <div class="landscapeOnly">
           <label>Red:</label><br>
-          <paper-input value="{{immediateColor.0}}" type="number" min="0" max="255"></paper-input>
+          <paper-input id="redField" value="{{immediateColor.0}}" on-input="changeColorMixture" type="number" min="0" max="255"></paper-input>
         </div>
         <div class="landscapeOnly">
           <label>Green:</label><br>
-          <paper-input value="{{immediateColor.1}}" type="number" min="0" max="255"></paper-input>
+          <paper-input id="greenField" value="{{immediateColor.1}}" on-input="changeColorMixture" type="number" min="0" max="255"></paper-input>
         </div>
         <div class="landscapeOnly">
           <label>Blue:</label><br>
-          <paper-input value="{{immediateColor.2}}" type="number" min="0" max="255"></paper-input>
+          <paper-input id="blueField" value="{{immediateColor.2}}" on-input="changeColorMixture" type="number" min="0" max="255"></paper-input>
         </div>
         
       </div>
@@ -314,6 +314,13 @@ There are three different main configurations the dialog allows, `circle`, `squa
         var rect = this.$.huePicker.getBoundingClientRect();
         var percentage = (e.x - rect.left) / rect.width;
         this.colorHue = percentage;
+      },
+      changeColorMixture: function() {
+        var red = this.$.redField.value;
+        var green = this.$.greenField.value;
+        var blue = this.$.blueField.value;
+        var colors = [red, green, blue];
+        this.set('immediateColor', colors);
       },
       setColor: function () {
         this.color = this.immediateColor;


### PR DESCRIPTION
I've updated the element to work in Polymer 1.* #4 and did some minor improvements:
 - improve paper ripple design (commit bfa3b75054c044fda74548a160575788ce1177f3)
 - change cursor on color-circle to crosshair (commit 098134033c2bebe7e4e7c188cb7a4f728622295d)
 - add scale-up and 
   fade-out animation to paper-dialog (commit 6278d258ec73db3609e8fe1617e11af40f11e72d)
 - add iron-components-page and link it to the demo for better documentation on the element (commits 11bf1d5171a30a52c9d0103a51567d7da5ade38e 44f9efcb74e40d6ee8f69282cdcc21a606237d6c 0c677463eb36e3bcb1d8973ce9966e88b2967347)

TODO: I don't how you wanted to implement huebox, so I left it out