### PR TITLE
Float offset fix

### DIFF
--- a/paper-color-circle.html
+++ b/paper-color-circle.html
@@ -321,8 +321,8 @@
         redraw: function(){
           this.debounce('redraw', function(){
             var size = this.getBoundingClientRect();
-            var width = size.width;
-            var height = size.height;
+            var width = Math.floor(size.width);
+            var height = Math.floor(size.height);
             if(width == 0 || height == 0){
               var computedStyle = window.getComputedStyle(this);
               width = parseInt(computedStyle.width);

--- a/paper-color-circle.html
+++ b/paper-color-circle.html
@@ -321,14 +321,14 @@
         redraw: function(){
           this.debounce('redraw', function(){
             var size = this.getBoundingClientRect();
-            var width = Math.floor(size.width);
-            var height = Math.floor(size.height);
+            var width = size.width;
+            var height = size.height;
             if(width == 0 || height == 0){
               var computedStyle = window.getComputedStyle(this);
               width = parseInt(computedStyle.width);
               height = parseInt(computedStyle.height);
             }
-            this.size = Math.min(width, height);
+            this.size =  Math.floor(Math.min(width, height));
             this.$.canvas.width = this.size;
             this.$.canvas.height = this.size;
             this.$.rippleContainer.style.width = this.size + 'px';


### PR DESCRIPTION
getBoundingClientRect() returns float numbers ( https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIDOMClientRect ) and therefore the bitmap offset, which uses this.size (which is derived from the rectangle) can become a float in some cases.
This results in breaking the whole canvas bitmap drawing (i.e. the color circle disappears), as arrays expect integers as indexers.
In my case the color circle/square disappeared as soon as the color picker paper dialog was opened.
Using  Math.floor before setting this.size solves the problem.
