### PR TITLE
Fixes to improve binding with other engines

### DIFF
--- a/paper-color-input.html
+++ b/paper-color-input.html
@@ -172,15 +172,16 @@ There are three different main configurations all 3 elements allow: `circle`, `s
 				'input.tap': 'openColorPicker'
 			},
 			// Element Lifecycle
-			ready: function() {
+			attached: function() {
 				if(this._isValueDefined()){
-					this.$.picker.set('immediateColor', this.value);
 					var listenOnce;
 					this.$.picker.addEventListener('immediate-color-as-string-changed', listenOnce = function(){
 						//this.colorName = this.$.picker.immediateColorAsString;
 						this.$.picker.setColor();
 						this.$.picker.removeEventListener('immediate-color-as-string-changed', listenOnce);
 					}.bind(this));
+
+					this.$.picker.set('immediateColor', this.value);
 				}
 			},
 			openColorPicker: function(){

--- a/paper-color-input.html
+++ b/paper-color-input.html
@@ -181,7 +181,7 @@ There are three different main configurations all 3 elements allow: `circle`, `s
 						this.$.picker.removeEventListener('immediate-color-as-string-changed', listenOnce);
 					}.bind(this));
 
-					this.$.picker.set('immediateColor', this.value);
+					this.$.picker.set('immediateColor', JSON.parse(JSON.stringify(this.value)));
 				}
 			},
 			openColorPicker: function(){

--- a/paper-color-picker.html
+++ b/paper-color-picker.html
@@ -544,7 +544,7 @@ and to open the dialog
         },
         open: function(){
           if (this.color && this.color['green'])
-            this.immediateColor = this.color;
+            this.immediateColor = JSON.parse(JSON.stringify(this.color));
           this.immediateColorChanged();
           this.$.dialog.open();
           if (this._showHuePicker())


### PR DESCRIPTION
Binding engines such as Aurelia don’t have the value provided to the
element at `ready` time. Using `attached` allows binding engines a
chance to provide an initial value.

This also moves the setting of `immediateColor` to after the “listen
once” event subscription so that it will be guaranteed to fire, even on
fast hardware.
