### PR TITLE
Remove arrow function to fix Safari

### DIFF
--- a/paper-color-picker.html
+++ b/paper-color-picker.html
@@ -485,13 +485,13 @@ and to open the dialog
                 color: undefined,
                 distance: Infinity
               };
-              colors.forEach((color) => {
+              colors.forEach(function(color) {
                 var distance = Math.sqrt(Math.pow(this.immediateColor['red']-color.rgb[0],2)+Math.pow(this.immediateColor['green']-color.rgb[1],2)+Math.pow(this.immediateColor['blue']-color.rgb[2],2));
                 if(distance < closest.distance){
                   closest.color = color;
                   closest.distance = distance;
                 }
-              });
+              }.bind(this));
               this.immediateColorAsString = closest.color.title;
 
               var luminance = Math.max(this._calculateLuminance.apply(this, closest.color.rgb), Math.min(1,1-this.immediateColor.alpha+0.2));


### PR DESCRIPTION
Safari does not currently support arrow functions. This commit replaces
a single arrow function with its equivalent.
