### PR TITLE
workaround `this.valueAsHex` returing non-string values in some cases

### DIFF
--- a/paper-color-input.html
+++ b/paper-color-input.html
@@ -214,6 +214,10 @@ There are three different main configurations all 3 elements allow: `circle`, `s
 			},
 			_setValueFromHex: function(){
 				var hex = this.valueAsHex;
+				if (typeof hex != 'string') {
+				  this.set('value', {});
+				  return;
+				}
 				var shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
 				var hex = hex.replace(shorthandRegex, function(m, r, g, b) {
 					return r + r + g + g + b + b;


### PR DESCRIPTION
In some cases, `this.valueAsHex` was returning `false` and other non-string values. I couldn't track down the problem entirely, but this stopped the script from throwing errors whenever it hit those values.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/david-mulder/paper-color-picker/27)

<!-- Reviewable:end -->
