### PR TITLE
fix calculation of valueAsHex

### DIFF
--- a/paper-color-input.html
+++ b/paper-color-input.html
@@ -203,7 +203,7 @@ There are three different main configurations all 3 elements allow: `circle`, `s
 					var hex = '#';
 					var value = this.value;
 					['red', 'green', 'blue'].forEach(function(c){
-						var h = value[c].toString(16);
+						var h = parseInt(value[c], 10).toString(16);
 						l = h.length;
 						hex += l < 2 ? '0' : '';
 						hex += l < 1 ? '0' : '';


### PR DESCRIPTION
This addresses an issue where the `_setValueAsHexFromValue` method wouldn't convert the `String` values captured from the `input` fields, resulting in invalid computed hex strings. This patch parses these values as integers before continuing with the hex string calculation.

This error seems to have started with Polymer 1.7, but I'm unsure if that is indeed the root cause. I don't know why it worked previously, but now does not. Regardless, this fixes the issue.