### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,13 +15,13 @@
   ],
   "license": "https://github.com/David-Mulder/paper-color-picker/blob/master/LICENSE",
   "dependencies": {
-    "paper-dialog": "PolymerElements/paper-dialog#~1.0.3",
-    "iron-component-page": "PolymerElements/iron-component-page#~1.1.2",
-    "paper-slider": "PolymerElements/paper-slider#~1.0.8",
-    "neon-animation": "PolymerElements/neon-animation#~1.0.8",
-    "paper-styles": "PolymerElements/paper-styles#~1.0.13",
+    "paper-dialog": "PolymerElements/paper-dialog#^1.0.3",
+    "iron-component-page": "PolymerElements/iron-component-page#^1.1.2",
+    "paper-slider": "PolymerElements/paper-slider#^1.0.8",
+    "neon-animation": "PolymerElements/neon-animation#^1.0.8",
+    "paper-styles": "PolymerElements/paper-styles#^1.0.13",
     "whenever.js": "David-Mulder/whenever.js#~0.0.1",
-    "iron-form-element-behavior": "PolymerElements/iron-form-element-behavior#~1.0.6",
-    "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#~1.0.2"
+    "iron-form-element-behavior": "PolymerElements/iron-form-element-behavior#^1.0.6",
+    "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#^1.0.2"
   }
 }


### PR DESCRIPTION
PolymerElements should use `^` versus `~` to eliminate dependency conflicts on projects that have other elements using the same PolymerElements.
